### PR TITLE
change ElasticTableGateway.php check id from isset to !empty

### DIFF
--- a/src/TableGateway/ElasticTableGateway.php
+++ b/src/TableGateway/ElasticTableGateway.php
@@ -60,7 +60,7 @@ class ElasticTableGateway implements TableGatewayInterface
             $this->collectionName,
             $this->documentType,
             $data,
-            (isset($id) ? $id : null),
+            (!empty($id) ? $id : null),
             $options
         );
         return ['_id' => $result['_id']];


### PR DESCRIPTION
change ElasticTableGateway.php insert check id from `isset` to `!empty` because if `$id = ''` then `isset = true`, but  `!emtpy = false`. This is fix elastic error 405.